### PR TITLE
feat: add security headers and https redirect

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,7 +1,66 @@
 import type { NextConfig } from "next";
 
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+// mapbox ships its gl worker as a blob; lordicon icons are fetched as lottie json
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://api.mapbox.com",
+  "font-src 'self' data:",
+  `connect-src 'self' ${apiUrl} https://api.mapbox.com https://events.mapbox.com https://cdn.lordicon.com https://ip.radsoft.cloud`,
+  "worker-src 'self' blob:",
+  "child-src 'self' blob:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+]
+  .join("; ")
+  .replace(/\s+/g, " ")
+  .trim();
+
 const nextConfig: NextConfig = {
-  output: 'standalone',
+  output: "standalone",
+  poweredByHeader: false,
+
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        // ingress terminates tls, so the original scheme only survives in this header
+        has: [{ type: "header", key: "x-forwarded-proto", value: "http" }],
+        destination: "https://bluerelief.app/:path*",
+        permanent: true,
+      },
+    ];
+  },
+
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(self), payment=()",
+          },
+          { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+          // report-only until we confirm nothing legitimate is blocked
+          { key: "Content-Security-Policy-Report-Only", value: csp },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Context

Investigating reports of a fake reCAPTCHA "Verification Steps" dialog appearing over the app. That dialog is **not served by us** — verified clean at every layer:

| Check | Result |
|---|---|
| `origin/main` tree + deployed image `v1.53.0-8531371` | no captcha code; only legit `clipboard.writeText` calls |
| Origin HTML from LAN, external IP, and Chrome UA | byte-identical, 0 markers |
| All 19 JS chunks + all 4 containers (`exec` verified) | clean |
| Ingress annotations / `sub_filter` | none; `allow-snippet-annotations: "false"` cluster-wide |
| Image digests | consistent across pods |

It's client-side injection. DevTools on an affected machine shows 11 requests to `bsc-testnet-rpc.publicnode.com` with our Referer — **EtherHiding**, where the payload lives in a BNB Chain smart contract and is pulled via RPC.

## Changes

Hardens `client/next.config.ts`:

- **HSTS** `max-age=63072000; includeSubDomains; preload`
- **HTTP→HTTPS redirect** — `http://bluerelief.app` currently returns `200 OK` in plaintext instead of redirecting. Keyed on `x-forwarded-proto` since ingress-nginx terminates TLS.
- `X-Frame-Options: DENY`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, `Cross-Origin-Opener-Policy`
- `poweredByHeader: false` — stop advertising `X-Powered-By: Next.js`
- **CSP (Report-Only)** with `connect-src` allowlisting only what the client uses: API, `api.mapbox.com`, `events.mapbox.com`, `cdn.lordicon.com`, `ip.radsoft.cloud`

## Why CSP matters here

If the injected script runs in the page's **main world**, `connect-src` blocks the BSC RPC call and kills the payload fetch. If it runs as an extension content script in an isolated world, CSP won't reach it. Either way the allowlist is correct and overdue.

Shipped as **Report-Only** so it cannot break production on first deploy. Recommend flipping to enforcing (`Content-Security-Policy`) once reports confirm nothing legitimate is blocked.

## Not a fix for the malware

This does not remove the injection. The actual fix is identifying and removing the malicious browser extension on affected machines. Blocking `bsc-testnet-rpc.publicnode.com` at DNS is a stopgap.

## Testing

⚠️ **Build not verified** — `node_modules` was not installed in the working environment, so this has not been typechecked or built. Needs `bun install && bun run build` before merge.

Verify after deploy:
```
curl -sI https://bluerelief.app | grep -iE "strict-transport|x-frame|content-security"
curl -sI http://bluerelief.app | head -1   # expect 301
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added enhanced browser security protections, including content security policy reporting, strict transport security, clickjacking protection, and safer referrer and permissions policies.
  * Disabled exposure of the framework-powered response header.

* **Routing**
  * HTTP requests are now permanently redirected to the secure site address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->